### PR TITLE
Supports linking ggtreeExtra

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,4 @@
++ supports linking `ggtreeExtra`. (2021-01-21, Thu)
 + added a new view called `by_conservation`.(2020-12-22, Tue)
 + added a new color scheme `Hydrophobicity` and a new paramter `border`.(2020-12-21, Mon)
 + rewrite the function `facet_msa()`.(2020-12-03, Thu)

--- a/R/geom_msa.R
+++ b/R/geom_msa.R
@@ -19,6 +19,8 @@
 ##' @param disagreement a logical value. Displays characters that disagreememt to consensus(excludes ambiguous disagreements).
 ##' @param ignore_gaps a logical value. When selected TRUE, gaps in column are treated as if that row didn't exist.
 ##' @param ref a character string. Specifying the reference sequence which should be one of input sequences when 'consensus_views' is TRUE.
+##' @param position Position adjustment, either as a string, or the result of a call to a position adjustment function,
+##' default is 'identity' meaning 'position_identity()'.
 ##' @param ... additional parameter
 ##' @return A list
 ##' @importFrom utils modifyList
@@ -26,12 +28,10 @@
 ##' @author Guangchuang Yu
 geom_msa <- function(data, font = "helvetical", mapping = NULL, color = "Chemistry_AA", custom_color = NULL, order = NULL, char_width = 0.9,
                      none_bg = FALSE, by_conservation = FALSE, posHighligthed = NULL, seq_name = NULL, border = NULL,
-                     consensus_views = FALSE, use_dot = FALSE, disagreement = TRUE, ignore_gaps = FALSE, ref = NULL, ... ) {
-
+                     consensus_views = FALSE, use_dot = FALSE, disagreement = TRUE, ignore_gaps = FALSE, ref = NULL, position="identity",... ) {
     data <- msa_data(data, font = font, color = color, custom_color = custom_color, order = order, char_width = char_width, by_conservation = by_conservation,
                      consensus_views  = consensus_views,use_dot = use_dot, disagreement = disagreement,ignore_gaps = ignore_gaps, ref = ref)
     bg_data <- data
-
     if(is.null(mapping)) {
         mapping <- aes_(x = ~position, y = ~name, fill = ~I(color))
     }
@@ -50,11 +50,10 @@ geom_msa <- function(data, font = "helvetical", mapping = NULL, color = "Chemist
         mapping <- modifyList(mapping, aes_(x = ~position, fill = ~character, width = 1))
     }
     if(is.null(border)){
-        ly_bg <- geom_tile(mapping = mapping, data = bg_data, color = 'grey', inherit.aes = FALSE)
+        ly_bg <- geom_tile(mapping = mapping, data = bg_data, color = 'grey', inherit.aes = FALSE, position = position)
     }else{
-        ly_bg <- geom_tile(mapping = mapping, data = bg_data, color = border, inherit.aes = FALSE)
+        ly_bg <- geom_tile(mapping = mapping, data = bg_data, color = border, inherit.aes = FALSE, position = position)
     }
-
     if (!all(c("yy", "order", "group") %in% colnames(data))) {
         return(ly_bg)
     }
@@ -67,8 +66,7 @@ geom_msa <- function(data, font = "helvetical", mapping = NULL, color = "Chemist
     if (consensus_views && !use_dot) {
         label_mapping <- modifyList(label_mapping, aes_(fill = ~I(font_color)))
     }
-
-    ly_label <- geom_polygon(mapping = label_mapping, data = data, inherit.aes = FALSE)
+    ly_label <- geom_polygon(mapping = label_mapping, data = data, inherit.aes = FALSE, position=position)
     if (none_bg & is.null(posHighligthed)) { #paramter 'none_bg' work
         return(ly_label)
     }

--- a/man/geom_msa.Rd
+++ b/man/geom_msa.Rd
@@ -22,6 +22,7 @@ geom_msa(
   disagreement = TRUE,
   ignore_gaps = FALSE,
   ref = NULL,
+  position = "identity",
   ...
 )
 }
@@ -60,6 +61,9 @@ If font = NULL, only plot the background tile.}
 \item{ignore_gaps}{a logical value. When selected TRUE, gaps in column are treated as if that row didn't exist.}
 
 \item{ref}{a character string. Specifying the reference sequence which should be one of input sequences when 'consensus_views' is TRUE.}
+
+\item{position}{Position adjustment, either as a string, or the result of a call to a position adjustment function,
+default is 'identity' meaning 'position_identity()'.}
 
 \item{...}{additional parameter}
 }


### PR DESCRIPTION
update geom_msa and msa_data to support linking [`ggtreeExtra`](https://github.com/YuLab-SMU/ggtreeExtra).

```
library(ggmsa)
library(ggplot2)
library(ggtree)
library(ggtreeExtra)
library(Biostrings)
protein_sequences <- system.file("extdata", "sample.fasta", package = "ggmsa")

x <- readAAStringSet(protein_sequences)
d <- as.dist(stringDist(x, method = "hamming")/width(x)[1])
library(ape)
tree <- bionj(d)

data = tidy_msa(x, 164, 213)
p1 <- ggtree(tree) + geom_tiplab(size=2)

p2 <- p1 +
      geom_fruit(
          data = data,
          geom = geom_msa,
          offset = 1,
          pwidth =5
      )
p2
```
![test](https://user-images.githubusercontent.com/17870644/105330545-62fcd880-5c0d-11eb-84aa-d4baebbd3d0a.png)
